### PR TITLE
create or overwrite configuration file

### DIFF
--- a/src/DocumentDbExplorer/Services/SettingsService.cs
+++ b/src/DocumentDbExplorer/Services/SettingsService.cs
@@ -76,10 +76,9 @@ namespace DocumentDbExplorer.Services
 
         private async Task SaveAsync(IEnumerable<Connection> connections)
         {
-
             var json = JsonConvert.SerializeObject(connections);
 
-            using (var fs = File.Open(_configurationFilePath, FileMode.Truncate))
+            using (var fs = File.Open(_configurationFilePath, FileMode.Create))
             {
                 var info = new UTF8Encoding(true).GetBytes(json);
                 await fs.WriteAsync(info, 0, info.Length);


### PR DESCRIPTION
I've got `System.IO.FileNotFoundException: 'Could not find file 'C:\Users\<username>\AppData\Local\DocumentDbExplorer\connection-settings.json'.'` on app first launch.
Changing to `FileMode.Create` instead of `FileMode.Truncate` fixes issue.
Opening file with `FileMode.Create` will create new file if doesn't exist or overwrite existing.